### PR TITLE
Change enumeration for cover art filenames from max 999 to max 9

### DIFF
--- a/Playbox.widget/lib/Get Current Track.applescript
+++ b/Playbox.widget/lib/Get Current Track.applescript
@@ -154,7 +154,7 @@ on getLocaliTunesArt()
 			set ext to ".jpg"
 		end if
 	end tell
-	set fileName to (mypath as POSIX file) & "cover" & (random number from 0 to 999) & ext as string -- get the filename to ~/my path/cover.ext
+	set fileName to (mypath as POSIX file) & "cover" & (random number from 0 to 9) & ext as string -- get the filename to ~/my path/cover.ext
 	set outFile to open for access file fileName with write permission -- write to file
 	set eof outFile to 0 -- truncate the file
 	write srcBytes to outFile -- write the image bytes to the file


### PR DESCRIPTION
Fix for: https://github.com/Pe8er/Playbox.widget/issues/28

Cover art was being saved to disk with a random suffix between 0 and 999. Since this was done separately for .png and .jpg files, with time, a user would have 2,000 files cached to disk.

While there is no mechanism in place that I noticed for deleting the cache, old files were overwritten when the same random number was selected. 

I simply changed the max random number to 9 so that at maximum a user will have 20 files cached to disk. This seems much more manageable. The change saved us 1GB in disk space.

(Caveat to everything above: I am by no means an AppleScript expert and didn't study the code carefully but this should be a fairly straightforward change.)